### PR TITLE
Add support for --number and --verbose arguments to the test subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ What it can do:
 - [x] Run and compile your code
 - [x] Download all test cases
 - [x] Run your test cases locally
-  - [ ] Run a specific test case
+  - [x] Run a specific test case
 - [x] Generate a report for the test cases output
 - [x] Send your submission to run.codes
 - [ ] Show your run.codes results

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,9 +24,13 @@ pub fn cli() -> Command<'static> {
 		.subcommand(Command::new("build").about("Compile the project"))
 		.subcommand(Command::new("run").about("Runs the project"))
 		.subcommand(
-			Command::new("test").about("Run all test cases").arg(
+			Command::new("test").about("Run all test cases")
+			.arg(
 				arg!(-n --number <TEST_CASE_NUMBER> "Specify witch test run")
 					.required(false)
+			)
+			.arg(arg!(-v --verbose "Print the expected output and the output")
+				.required(false)
 			),
 		)
 		.subcommand(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,7 +27,6 @@ pub fn cli() -> Command<'static> {
 			Command::new("test").about("Run all test cases").arg(
 				arg!(-n --number <TEST_CASE_NUMBER> "Specify witch test run")
 					.required(false)
-					.allow_invalid_utf8(true),
 			),
 		)
 		.subcommand(

--- a/src/sub_commands/test.rs
+++ b/src/sub_commands/test.rs
@@ -91,6 +91,63 @@ pub fn save_diff(
 	.expect("failed to save test diff file");
 }
 
+pub fn run_single_test(test_case_name: &String) -> Result<Option<i32>, std::io::Error> {
+	let test_output = run_test_case(&test_case_name);
+	let time_stamp = chrono::offset::Local::now()
+		.format("%d-%m-%Y_%H:%M:%S")
+		.to_string();
+
+	std::fs::create_dir_all(format!(
+		"./test-cases/local-attempts/{}/{}",
+		&time_stamp, test_case_name
+	))
+	.unwrap();
+
+	test_output.save(format!(
+		"./test-cases/local-attempts/{}/{1}/{1}",
+		time_stamp, test_case_name
+	));
+
+	if test_output.error {
+		println!("Test {}: {}", test_case_name, "Failed".bold().red());
+		println!("\n{}", test_output.stderr);
+		return Err(std::io::Error::new(
+				std::io::ErrorKind::Other, "Test Output Failed",));
+	}
+
+	let (diff_code, diff_stderr, diff_stdout) = diff(
+		format!("./test-cases/outputs/{0}/{0}.out", test_case_name),
+		format!("./test-cases/local-attempts/{1}/{0}/{0}.out",
+			test_case_name, time_stamp
+		),
+	);
+
+	match diff_code {
+		Some(0) => println!("Test {}: {}, {} ms",
+			test_case_name,
+			"Passed".bold().green(),
+			test_output.cpu_time
+		),
+		Some(1) => println!("Test {}: {}", test_case_name, "Failed".bold().red()),
+		Some(2) => println!(
+			"Test {}: Missing test files\n\n {}",
+			test_case_name, diff_stderr
+		),
+		Some(code) => panic!("Test {}: Unexpected exit code {}", test_case_name, code),
+		None => (),
+	}
+
+	save_diff(
+		&diff_stdout,
+		&diff_stderr,
+		&diff_code,
+		&time_stamp,
+		&test_case_name,
+	);
+
+	Ok(diff_code)
+}
+
 pub fn run_all_tests() {
 	let mut errors_counter = 0;
 	let mut passed_counter = 0;
@@ -123,51 +180,13 @@ pub fn run_all_tests() {
 		))
 		.unwrap();
 
-		let test_output = run_test_case(&test_case_name);
-
-		test_output.save(format!(
-			"./test-cases/local-attempts/{}/{1}/{1}",
-			time_stamp, test_case_name
-		));
-
-		if test_output.error {
-			println!("Test {}: {}", test_case_name, "Failed".bold().red());
-			errors_counter += 1;
-			println!("\n{}", test_output.stderr);
-			continue;
-		}
-
-		let (diff_code, diff_stderr, diff_stdout) = diff(
-			format!("./test-cases/outputs/{0}/{0}.out", test_case_name),
-			format!(
-				"./test-cases/local-attempts/{1}/{0}/{0}.out",
-				test_case_name, time_stamp
-			),
-		);
-
-		match diff_code {
-			Some(0) => println!(
-				"Test {}: {}, {} ms",
-				test_case_name,
-				"Passed".bold().green(),
-				test_output.cpu_time
-			),
-			Some(1) => println!("Test {}: {}", test_case_name, "Failed".bold().red()),
-			Some(2) => println!(
-				"Test {}: Missing test files\n\n {}",
-				test_case_name, diff_stderr
-			),
-			Some(code) => panic!("Test {}: Unexpected exit code {}", test_case_name, code),
-			None => (),
-		}
-
-		save_diff(
-			&diff_stdout,
-			&diff_stderr,
-			&diff_code,
-			&time_stamp,
-			&test_case_name,
-		);
+		let diff_code = match run_single_test(&test_case_name) {
+			Ok(diff_code) => diff_code,
+			Err(_error) => {
+				errors_counter += 1;
+				continue;
+			},
+		};
 
 		match diff_code {
 			Some(0) => passed_counter += 1,
@@ -196,9 +215,15 @@ pub fn run(args: &clap::ArgMatches) {
 		return;
 	}
 
-	if !args.is_present("number") {
-		run_all_tests();
+	if args.is_present("number") {
+		match run_single_test(&args.value_of("number").unwrap().to_string()) {
+			Ok(diff_code) => diff_code,
+			Err(_error) => {
+				println!("{}", format!("Error running the test case").bold().red());
+				return;
+			},
+		};
 	} else {
-		println!("sorry, not implemented yet, but you can contribute in: https://github.com/Math-42/run-cli");
+		run_all_tests();
 	}
 }


### PR DESCRIPTION
Add support for --number and --verbose arguments to the test subcommand.

**Known Issues:** the arguments for --number are not necessarily numeric and can be greater than the number of tests. First, it is needed to save the number of tests in a structure and then implement this limit.